### PR TITLE
Manufacturing - OVMS Helm Chart

### DIFF
--- a/contoso_manufacturing/operations/charts/ovms/.helmignore
+++ b/contoso_manufacturing/operations/charts/ovms/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/contoso_manufacturing/operations/charts/ovms/Chart.yaml
+++ b/contoso_manufacturing/operations/charts/ovms/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: ovms
+description: this chart deploys the OpenVINO Model Server (OVMS) and Agora-specific models
+type: application
+version: 0.1.0

--- a/contoso_manufacturing/operations/charts/ovms/configs/config.json
+++ b/contoso_manufacturing/operations/charts/ovms/configs/config.json
@@ -1,0 +1,51 @@
+{
+    "model_config_list": [
+         {
+            "config": {
+                "name": "yolov8n",
+                "base_path": "/models/yolov8n",
+                "batch_size": "auto"
+            }
+         },
+         {
+            "config": {
+                "name": "human-pose-estimation",
+                "base_path": "/models/human-pose-estimation",
+                "batch_size": "auto"
+            }
+        },
+        {
+            "config": {
+                "name": "weld-porosity-detection",
+                "base_path": "/models/weld-porosity-detection",
+                "batch_size": "auto"
+            }
+        },
+        {
+            "config": {
+                "name": "head-pose-estimation",
+                "base_path": "/models/head-pose-estimation",
+                "batch_size": "auto"
+            }
+        },
+        {
+            "config": {
+                "name": "safety-yolo8",
+                "base_path": "/models/safety-yolo8",
+                "batch_size": "auto"
+            }
+        },
+        {
+            "config": {
+                "name": "time-series-forecasting-electricity",
+                "base_path": "/models/forecasting-electricity",
+                "batch_size": "auto"
+            }
+        }
+    ],
+    "monitoring": {
+        "metrics": {
+            "enable": true
+        }
+    }
+ }

--- a/contoso_manufacturing/operations/charts/ovms/templates/_helpers.tpl
+++ b/contoso_manufacturing/operations/charts/ovms/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "ovms.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "ovms.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "ovms.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "ovms.labels" -}}
+helm.sh/chart: {{ include "ovms.chart" . }}
+{{ include "ovms.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "ovms.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "ovms.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "ovms.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "ovms.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/contoso_manufacturing/operations/charts/ovms/templates/configmap.yaml
+++ b/contoso_manufacturing/operations/charts/ovms/templates/configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ovms-config
+  namespace: {{ .Release.Namespace }}
+data:
+  config.json: |
+{{ .Files.Get "configs/config.json" | nindent 4 }}

--- a/contoso_manufacturing/operations/charts/ovms/templates/job.yaml
+++ b/contoso_manufacturing/operations/charts/ovms/templates/job.yaml
@@ -1,0 +1,33 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: model-downloader-job
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "10"
+spec:
+  template:
+    spec:
+      containers:
+      - name: model-downloader
+        image: alpine
+        command: ["/bin/sh", "-c"]
+        args:
+        - |
+          wget -O /models/ovms_config.sh https://raw.githubusercontent.com/microsoft/jumpstart-agora-apps/manufacturing/contoso_manufacturing/deployment/configs/ovms_config.sh 
+          chmod +x /models/ovms_config.sh
+          /models/ovms_config.sh
+        volumeMounts:
+        - name: models-volume
+          mountPath: /models
+      volumes:
+      - name: models-volume
+        persistentVolumeClaim:
+          claimName: ovms-pvc
+      restartPolicy: Never
+  backoffLimit: 0

--- a/contoso_manufacturing/operations/charts/ovms/templates/modelserver.yaml
+++ b/contoso_manufacturing/operations/charts/ovms/templates/modelserver.yaml
@@ -1,0 +1,45 @@
+apiVersion: intel.com/v1alpha1
+kind: ModelServer
+metadata:
+  name: ovms
+  namespace: {{ .Release.Namespace }}
+spec:
+  image_name: openvino/model_server:latest
+  deployment_parameters:
+    replicas: {{ .Values.replicaCount }}
+    openshift_service_mesh: false
+    resources:
+      limits:
+        cpu: "1"
+        memory: "8192Mi"
+      requests:
+        cpu: "1"
+        memory: "8192Mi"
+  models_settings:
+    single_model_mode: false
+    config_configmap_name: "ovms-config"
+    config_path: ""
+    model_name: ""
+    model_path: ""
+    nireq: 0
+    plugin_config: '{"CPU_THROUGHPUT_STREAMS":"1"}'
+    batch_size: ""
+    shape: ""
+    model_version_policy: "{\"latest\": {\"num_versions\":1 }}"
+    layout: ""
+    target_device: "CPU"
+    is_stateful: false
+    idle_sequence_cleanup: false
+    low_latency_transformation: true
+    max_sequence_number: 0
+  server_settings:
+    file_system_poll_wait_seconds: 0
+    sequence_cleaner_poll_wait_minutes: 0
+    log_level: "INFO"
+  service_parameters:
+    grpc_port: 8080
+    rest_port: 8081
+    service_type: LoadBalancer
+  models_repository:
+    storage_type: "cluster"
+    models_volume_claim : "ovms-pvc"

--- a/contoso_manufacturing/operations/charts/ovms/templates/pvc.yaml
+++ b/contoso_manufacturing/operations/charts/ovms/templates/pvc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ovms-pvc
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "5"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: {{ .Values.storage.storageClassName }}
+  resources:
+    requests:
+      storage: {{ .Values.storage.resources.requests.storage }}

--- a/contoso_manufacturing/operations/charts/ovms/values.yaml
+++ b/contoso_manufacturing/operations/charts/ovms/values.yaml
@@ -1,0 +1,11 @@
+# Default values for ovms.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+storage:
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 2Gi


### PR DESCRIPTION
This is an initial commit to deploy OVMS. It assumes the following:

the Operator Lifecycle Manager has already been deployed to the cluster
the local-path storage class is already deployed; however, a different storage class can be used for testing by passing in, for example, --set storage.storageClassName=microk8s-hostpath
Additionally, to overcome a timing issue with the default Helm order of resource deployments whereby the ovms pod may be running without all the models being downloaded, Helm pre-install hooks are used to ensure that first the PVC is ready, then the job runs, and then following this the ModelServer gets deployed.