### PR TITLE
Manufacturing - Helm Chart for contoso-motors

### DIFF
--- a/contoso_manufacturing/operations/charts/contoso-motors/.helmignore
+++ b/contoso_manufacturing/operations/charts/contoso-motors/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/contoso_manufacturing/operations/charts/contoso-motors/Chart.yaml
+++ b/contoso_manufacturing/operations/charts/contoso-motors/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: contoso-motors
+description: A Helm chart to deploy components for the Contoso Motors scenario
+type: application
+version: 0.1.0
+appVersion: "1.16.0"
+dependencies:
+  - name: opcsimulator
+    version: 0.1.0
+    repository: "file://../opc-simulator"
+  - name: ovms
+    version: 0.1.0
+    repository: "file://../ovms"

--- a/contoso_manufacturing/operations/charts/contoso-motors/templates/_helpers.tpl
+++ b/contoso_manufacturing/operations/charts/contoso-motors/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "contoso-motors.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "contoso-motors.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "contoso-motors.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "contoso-motors.labels" -}}
+helm.sh/chart: {{ include "contoso-motors.chart" . }}
+{{ include "contoso-motors.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "contoso-motors.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "contoso-motors.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "contoso-motors.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "contoso-motors.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/contoso_manufacturing/operations/charts/contoso-motors/values.yaml
+++ b/contoso_manufacturing/operations/charts/contoso-motors/values.yaml
@@ -1,0 +1,3 @@
+# Default values for contoso-motors.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.

--- a/contoso_manufacturing/operations/contoso-motors-helm-release.yaml
+++ b/contoso_manufacturing/operations/contoso-motors-helm-release.yaml
@@ -1,0 +1,13 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: contoso-motors
+  namespace: default
+  annotations:
+    clusterconfig.azure.com/use-managed-source: "true"
+spec:
+  interval: 1m
+  releaseName: contoso-motors
+  chart:
+    spec:
+      chart: ./contoso_manufacturing/operations/charts/contoso-motors

--- a/contoso_manufacturing/operations/kustomization.yaml
+++ b/contoso_manufacturing/operations/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- contoso-motors-helm-release.yaml


### PR DESCRIPTION
This PR includes an initial contoso-motors Helm chart that contains sub-charts for the OPC simulator and OVMS.  While there are additional sub-charts to create, this should allow for the GitOps configuration to be tested.  It can be deployed via GitOps using the following.

```
az k8s-configuration flux create --cluster-name <cluster name> --resource-group <resource group> --name contoso-motors --namespace default --cluster-type connectedClusters --scope cluster --url https://github.com/mrhoads/jumpstart-agora-apps --branch manufacturing-helm-contoso-motors --sync-interval 3s --kustomization name=contoso-motors prune=false path=./contoso_manufacturing/operations
```

Note that the kustomization path must point to where the kustomization.yaml is; otherwise, Flux will use the manifests in the path tree and fail.  