### PR TITLE
Manufacturing - Modified Contoso Motors

### DIFF
--- a/contoso_manufacturing/operations/charts/influxdb/templates/_helpers.tpl
+++ b/contoso_manufacturing/operations/charts/influxdb/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "influxdb.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "influxdb.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "influxdb.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "influxdb.labels" -}}
+helm.sh/chart: {{ include "influxdb.chart" . }}
+{{ include "influxdb.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "influxdb.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "influxdb.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "influxdb.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "influxdb.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/contoso_manufacturing/operations/charts/influxdb/templates/influxdb-configmap.yaml
+++ b/contoso_manufacturing/operations/charts/influxdb/templates/influxdb-configmap.yaml
@@ -2,7 +2,13 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: dashboard-config
-  namespace: azure-iot-operations
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: "influxdb"
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "5"

--- a/contoso_manufacturing/operations/charts/influxdb/templates/influxdb-import-dashboard.yaml
+++ b/contoso_manufacturing/operations/charts/influxdb/templates/influxdb-import-dashboard.yaml
@@ -3,7 +3,13 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: influxdb-import-dashboard-01
-  namespace: azure-iot-operations
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: "influxdb"
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "20"
@@ -41,7 +47,13 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: influxdb-import-dashboard-02
-  namespace: azure-iot-operations
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: "influxdb"
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "20"
@@ -80,7 +92,13 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: influxdb-import-dashboard-03
-  namespace: azure-iot-operations
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: "influxdb"
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "20"

--- a/contoso_manufacturing/operations/charts/influxdb/templates/influxdb-setup.yaml
+++ b/contoso_manufacturing/operations/charts/influxdb/templates/influxdb-setup.yaml
@@ -2,7 +2,13 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: bash-influx-setup-job
-  namespace: azure-iot-operations
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: "influxdb"
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "15" 
@@ -18,7 +24,7 @@ spec:
           #!/bin/bash
 
           # Run the influx setup command and capture any output and error
-          output=$(influx setup --host http://influxdb.azure-iot-operations.svc.cluster.local:8086 --bucket manufacturing --org InfluxData --password "s1$mpl3p4ssw0rd" --username admin --token secret-token --force 2>&1)
+          output=$(influx setup --host http://influxdb.contoso-motors.svc.cluster.local:8086 --bucket manufacturing --org InfluxData --password "s1$mpl3p4ssw0rd" --username admin --token secret-token --force 2>&1)
 
           # If the command was successful, print the output and exit
           if [ $? -eq 0 ]; then

--- a/contoso_manufacturing/operations/charts/influxdb/templates/influxdb-setup.yaml
+++ b/contoso_manufacturing/operations/charts/influxdb/templates/influxdb-setup.yaml
@@ -24,7 +24,7 @@ spec:
           #!/bin/bash
 
           # Run the influx setup command and capture any output and error
-          output=$(influx setup --host http://influxdb.contoso-motors.svc.cluster.local:8086 --bucket manufacturing --org InfluxData --password "s1$mpl3p4ssw0rd" --username admin --token secret-token --force 2>&1)
+          output=$(influx setup --host http://influxdb.contoso-motors.svc.cluster.local:8086 --bucket manufacturing --org InfluxData --password ArcPassword123!! --username admin --token secret-token --force 2>&1)
 
           # If the command was successful, print the output and exit
           if [ $? -eq 0 ]; then

--- a/contoso_manufacturing/operations/charts/influxdb/templates/influxdb.yaml
+++ b/contoso_manufacturing/operations/charts/influxdb/templates/influxdb.yaml
@@ -2,7 +2,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: contosoba
-  namespace: azure-iot-operations
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kuberenetes.io/name: "influxdb"
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "10"
@@ -21,13 +27,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: contosoba
-  namespace: azure-iot-operations
+  namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: contosoba-role
-  namespace: azure-iot-operations
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "10"
@@ -38,13 +44,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: contosoba
-  namespace: azure-iot-operations
+  namespace: {{ .Release.Namespace }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: influxdb
-  namespace: azure-iot-operations
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "10" 
@@ -66,14 +72,14 @@ apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: influxdb-pv
-  namespace: azure-iot-operations 
+  namespace: {{ .Release.Namespace }}
   labels:
     type: local
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "8"
 spec:
-  storageClassName: manual
+  storageClassName: local-path
   capacity:
     storage: 5Gi
   accessModes:
@@ -85,7 +91,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: influxdb-pvc
-  namespace: azure-iot-operations
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "8"
@@ -101,7 +107,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: influxdb
-  namespace: azure-iot-operations   
+  namespace: {{ .Release.Namespace }}  
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "10"

--- a/contoso_manufacturing/operations/charts/influxdb/templates/influxdb.yaml
+++ b/contoso_manufacturing/operations/charts/influxdb/templates/influxdb.yaml
@@ -96,7 +96,7 @@ metadata:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "8"
 spec:
-  storageClassName: manual
+  storageClassName: local-path
   accessModes:
     - ReadWriteOnce
   resources:

--- a/contoso_manufacturing/operations/charts/influxdb/values.yaml
+++ b/contoso_manufacturing/operations/charts/influxdb/values.yaml
@@ -2,4 +2,4 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-influxDBEndpoint: "http://influxdb.azure-iot-operations.svc.cluster.local:8086"
+influxDBEndpoint: "http://influxdb.contoso-motors.svc.cluster.local:8086"

--- a/contoso_manufacturing/operations/charts/mqtt/templates/_helpers.tpl
+++ b/contoso_manufacturing/operations/charts/mqtt/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "mqtt.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "mqtt.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "mqtt.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "mqtt.labels" -}}
+helm.sh/chart: {{ include "mqtt.chart" . }}
+{{ include "mqtt.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "mqtt.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mqtt.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "mqtt.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "mqtt.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/contoso_manufacturing/operations/charts/mqtt/templates/mqtt-listener.yaml
+++ b/contoso_manufacturing/operations/charts/mqtt/templates/mqtt-listener.yaml
@@ -2,9 +2,14 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: mqtt-listener-deployment
-  namespace: azure-iot-operations
+  namespace: {{ .Release.Namespace }}
   labels:
     app: mqtt-listener
+    app.kubernetes.io/name: "mqtt"
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 spec:
   replicas: 1
   selector:

--- a/contoso_manufacturing/operations/charts/mqtt/templates/mqtt_simulator.yaml
+++ b/contoso_manufacturing/operations/charts/mqtt/templates/mqtt_simulator.yaml
@@ -2,7 +2,13 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: mqtt-simulator-deployment
-  namespace: azure-iot-operations
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: "mqtt"
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 spec:
   replicas: 1
   selector:

--- a/contoso_manufacturing/operations/charts/mqtt/values.yaml
+++ b/contoso_manufacturing/operations/charts/mqtt/values.yaml
@@ -2,6 +2,6 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-mqBrokerEndpoint: "dmqtt-frontend.contoso-motors.svc.cluster.local"
+mqBrokerEndpoint: "dmqtt-frontend.azure-iot-operations.svc.cluster.local"
 mqBrokerEndpointPort: "1883"
 influxDBEndpoint: "http://influxdb.contoso-motors.svc.cluster.local:8086"

--- a/contoso_manufacturing/operations/charts/mqtt/values.yaml
+++ b/contoso_manufacturing/operations/charts/mqtt/values.yaml
@@ -2,6 +2,6 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-mqBrokerEndpoint: "dmqtt-frontend.azure-iot-operations.svc.cluster.local"
+mqBrokerEndpoint: "dmqtt-frontend.contoso-motors.svc.cluster.local"
 mqBrokerEndpointPort: "1883"
-influxDBEndpoint: "http://influxdb.azure-iot-operations.svc.cluster.local:8086"
+influxDBEndpoint: "http://influxdb.contoso-motors.svc.cluster.local:8086"

--- a/contoso_manufacturing/operations/charts/opc-simulator/templates/opc-simulator.yaml
+++ b/contoso_manufacturing/operations/charts/opc-simulator/templates/opc-simulator.yaml
@@ -2,7 +2,13 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: opc-simulator
-  namepsace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: "opc-simulator"
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -35,6 +41,12 @@ kind: ConfigMap
 metadata:
   name: opc-simulator-config
   namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: "opc-simulator"
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 data:
   config.json: |
 {{ .Files.Get .Values.configFilePath | nindent 4 }}
@@ -43,7 +55,13 @@ apiVersion: v1
 kind: Service
 metadata:
   name: opcsimulator-service
-  namespace: {{.Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: "opc-simulator"
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 spec:
   ports:
     - port: 4840

--- a/contoso_manufacturing/operations/charts/ovms/templates/configmap.yaml
+++ b/contoso_manufacturing/operations/charts/ovms/templates/configmap.yaml
@@ -3,6 +3,15 @@ kind: ConfigMap
 metadata:
   name: ovms-config
   namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: "ovms"
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "10"
 data:
   config.json: |
 {{ .Files.Get "configs/config.json" | nindent 4 }}

--- a/contoso_manufacturing/operations/charts/ovms/templates/job.yaml
+++ b/contoso_manufacturing/operations/charts/ovms/templates/job.yaml
@@ -4,9 +4,11 @@ metadata:
   name: model-downloader-job
   namespace: {{ .Release.Namespace }}
   labels:
+    app.kubernetes.io/name: "ovms"
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "10"

--- a/contoso_manufacturing/operations/charts/ovms/templates/modelserver.yaml
+++ b/contoso_manufacturing/operations/charts/ovms/templates/modelserver.yaml
@@ -3,6 +3,15 @@ kind: ModelServer
 metadata:
   name: ovms
   namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: "ovms"
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "10"
 spec:
   image_name: openvino/model_server:latest
   deployment_parameters:

--- a/contoso_manufacturing/operations/charts/ovms/templates/pvc.yaml
+++ b/contoso_manufacturing/operations/charts/ovms/templates/pvc.yaml
@@ -3,6 +3,12 @@ kind: PersistentVolumeClaim
 metadata:
   name: ovms-pvc
   namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: "ovms"
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "5"

--- a/contoso_manufacturing/operations/charts/rtsp-simulator/templates/_helpers.tpl
+++ b/contoso_manufacturing/operations/charts/rtsp-simulator/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "rtsp-simulator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "rtsp-simulator.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "rtsp-simulator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "rtsp-simulator.labels" -}}
+helm.sh/chart: {{ include "rtsp-simulator.chart" . }}
+{{ include "rtsp-simulator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "rtsp-simulator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "rtsp-simulator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "rtsp-simulator.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "rtsp-simulator.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/contoso_manufacturing/operations/charts/rtsp-simulator/templates/rtsp-simulator.yaml
+++ b/contoso_manufacturing/operations/charts/rtsp-simulator/templates/rtsp-simulator.yaml
@@ -2,7 +2,13 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: virtual-rtsp
-  namespace: azure-iot-operations
+  namepsace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: "rtsp"
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 spec:
   replicas: 1
   selector:
@@ -50,8 +56,13 @@ apiVersion: v1
 kind: Service
 metadata:
   name: virtual-rtsp
-  namespace: azure-iot-operations
+  namespace: {{ .Release.Namespace }}
   labels:
+    app.kubernetes.io/name: "rtsp"
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     app: virtual-rtsp
 spec:
   type: LoadBalancer


### PR DESCRIPTION
This PR adds additional Helm labels and annotations.  In addition, it solidifies the use of the **contoso-motors** namespace.  Like earlier PRs, it requires the following:

- the OVMS CRDs and operator deployed as described [here](https://github.com/microsoft/jumpstart-agora-apps/blob/manufacturing/contoso_manufacturing/deployment/ovms.md)
- the dmqtt-frontend broker, not using authentication/authorization, to exist as a service in the azure-iot-operations namespace and listening on port 1883
- it changes the password of the InfluxDB credentials, since the dollar sign ('$') was resulting in errors of too short of a password being used.  This could/should be changed to be a value in the future.