### PR TITLE
Manufacturing - update RTSP to use values for video files

### DIFF
--- a/contoso_manufacturing/operations/charts/rtsp-simulator/templates/configmap.yaml
+++ b/contoso_manufacturing/operations/charts/rtsp-simulator/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rtsp-config
+data:
+  {{- range $model, $values := .Values.rtspModels }}
+  {{ $model }}_DOWNLOAD_URL: {{ $values.DOWNLOAD_URL | quote }}
+  {{ $model }}_SOURCE_URL: {{ $values.SOURCE_URL | quote }}
+  {{- end }}

--- a/contoso_manufacturing/operations/charts/rtsp-simulator/templates/rtsp-simulator.yaml
+++ b/contoso_manufacturing/operations/charts/rtsp-simulator/templates/rtsp-simulator.yaml
@@ -32,10 +32,16 @@ spec:
           - wget
           - "-O"
           - "/samples/helmet.mp4"
-          - https://jsfiles.blob.core.windows.net/video/agora/helmet-detection.mp4
+          - $(HELMET_DOWNLOAD_URL)
           volumeMounts:
           - name: tmp-samples
             mountPath: /samples
+          env:
+            - name: HELMET_DOWNLOAD_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: rtsp-config
+                  key: helmet_DOWNLOAD_URL
       containers:
         - name: virtual-rtsp-helmet
           image: "agoraarmbladev.azurecr.io/kerberos/virtual-rtsp:latest"
@@ -44,7 +50,10 @@ spec:
             - containerPort: 8554
           env:
             - name: SOURCE_URL
-              value: "file:///samples/helmet.mp4"
+              valueFrom:
+                configMapKeyRef:
+                  name: rtsp-config
+                  key: helmet_SOURCE_URL
           volumeMounts:
             - name: tmp-samples
               mountPath: /samples
@@ -107,10 +116,16 @@ spec:
           - wget
           - "-O"
           - "/samples/welding.mp4"
-          - https://jsfiles.blob.core.windows.net/video/agora/welding.mp4
+          - $(WELDING_DOWNLOAD_URL)
           volumeMounts:
           - name: tmp-samples
             mountPath: /samples
+          env:
+            - name: WELDING_DOWNLOAD_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: rtsp-config
+                  key: welding_DOWNLOAD_URL
       containers:
         - name: virtual-rtsp-welding
           image: "agoraarmbladev.azurecr.io/kerberos/virtual-rtsp:latest"
@@ -119,7 +134,10 @@ spec:
             - containerPort: 8554
           env:
             - name: SOURCE_URL
-              value: "file:///samples/welding.mp4"
+              valueFrom:
+                configMapKeyRef:
+                  name: rtsp-config
+                  key: welding_SOURCE_URL
           volumeMounts:
             - name: tmp-samples
               mountPath: /samples
@@ -182,10 +200,16 @@ spec:
           - wget
           - "-O"
           - "/samples/pose.mp4"
-          - https://jsfiles.blob.core.windows.net/video/agora/pose-estimation.mp4
+          - $(POSE_DOWNLOAD_URL)
           volumeMounts:
           - name: tmp-samples
             mountPath: /samples
+          env:
+            - name: POSE_DOWNLOAD_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: rtsp-config
+                  key: pose_DOWNLOAD_URL
       containers:
         - name: virtual-rtsp-pose
           image: "agoraarmbladev.azurecr.io/kerberos/virtual-rtsp:latest"
@@ -194,7 +218,10 @@ spec:
             - containerPort: 8554
           env:
             - name: SOURCE_URL
-              value: "file:///samples/pose.mp4"
+              valueFrom:
+                configMapKeyRef:
+                  name: rtsp-config
+                  key: pose_SOURCE_URL
           volumeMounts:
             - name: tmp-samples
               mountPath: /samples
@@ -222,3 +249,88 @@ spec:
       protocol: TCP  
   selector:
     app: virtual-rtsp-pose
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: virtual-rtsp-object
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: virtual-rtsp-object
+    app.kubernetes.io/name: "rtsp"
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: virtual-rtsp-object
+  minReadySeconds: 10
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        app: virtual-rtsp-object
+    spec:
+      initContainers:
+        - name: init-samples
+          image: alpine
+          command:
+          - wget
+          - "-O"
+          - "/samples/object-detection.mp4"
+          - $(OBJECT_DOWNLOAD_URL)
+          volumeMounts:
+          - name: tmp-samples
+            mountPath: /samples
+          env:
+            - name: OBJECT_DOWNLOAD_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: rtsp-config
+                  key: object_DOWNLOAD_URL
+      containers:
+        - name: virtual-rtsp-object
+          image: "agoraarmbladev.azurecr.io/kerberos/virtual-rtsp:latest"
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8554
+          env:
+            - name: SOURCE_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: rtsp-config
+                  key: object_SOURCE_URL
+          volumeMounts:
+            - name: tmp-samples
+              mountPath: /samples
+      volumes:
+        - name: tmp-samples
+          emptyDir: { }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: virtual-rtsp-object-svc
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: "rtsp"
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app: virtual-rtsp-object
+spec:
+  ports:
+    - port: 8554
+      targetPort: 8554
+      name: rtsp
+      protocol: TCP  
+  selector:
+    app: virtual-rtsp-object

--- a/contoso_manufacturing/operations/charts/rtsp-simulator/values.yaml
+++ b/contoso_manufacturing/operations/charts/rtsp-simulator/values.yaml
@@ -1,3 +1,16 @@
 # Default values for the rtsp-simulator.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+rtspModels:
+  pose:
+    DOWNLOAD_URL: "https://jsfiles.blob.core.windows.net/video/agora/pose-estimation.mp4"
+    SOURCE_URL: "file:///samples/pose.mp4"
+  object:
+    DOWNLOAD_URL: "https://jsfiles.blob.core.windows.net/video/agora/object-detection.mp4"
+    SOURCE_URL: "file:///samples/object-detection.mp4"
+  helmet:
+    DOWNLOAD_URL: "https://jsfiles.blob.core.windows.net/video/agora/helmet-detection.mp4"
+    SOURCE_URL: "file:///samples/helmet.mp4"
+  welding:
+    DOWNLOAD_URL: "https://jsfiles.blob.core.windows.net/video/agora/welding.mp4"
+    SOURCE_URL: "file:///samples/welding.mp4"


### PR DESCRIPTION
This changes the RTSP chart to use Helm values to populate a configmap, which should make it easier to modify URLs for the video locations